### PR TITLE
bump varint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/signed-varint.git"
   },
   "dependencies": {
-    "varint": "~3.0.0"
+    "varint": "~5.0.0"
   },
   "devDependencies": {
     "tape": "~2.12.3"


### PR DESCRIPTION
older versions of varint returns undefined when decoding invalid output causing https://github.com/dominictarr/signed-varint/blob/master/index.js#L11 to return NaN.

latest version just throws an exception instead