### PR TITLE
update varint and tape deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "git://github.com/dominictarr/signed-varint.git"
   },
   "dependencies": {
-    "varint": "~5.0.0"
+    "varint": "~6.0.0"
   },
   "devDependencies": {
-    "tape": "~2.12.3"
+    "tape": "~5.2.1"
   },
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
The new varint detects MAX_SAFE_INTEGER and adds bounds checking which were previously released, then reverted.

Also updates tape because, well, it was out of date.